### PR TITLE
Chore/008 version flag no in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Usage
 Usage: canteenmenu [options]
 
  Options:
--f --file The file that the data is written to.
--h --help This help information.
+-f    --file The file that the data is written to.
+-v --version Display the version of this program.
+-h    --help This help information.
 
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A fetcher and CSV2JSON converter for the canteen of the University of Regensburg
 ---------------------------------------------------------------------------------------------
 
 canteenmenu is a tool which lets you fetch the menu of the canteen of the
-University of Regensburg and out it as JSON.
+University of Regensburg and output it as JSON.
 
 Usage
 -----


### PR DESCRIPTION
As mentioned in  #9, this corrects `README.md`.

This includes the following changes:
 - added version commandline switches to the usage section
 - fixed a typo

fixes #9.